### PR TITLE
Fix for Safari on MacOS and iOS

### DIFF
--- a/src/components/control-component-factory.js
+++ b/src/components/control-component-factory.js
@@ -392,7 +392,7 @@ function createControlClass(s) {
         validateOn = updateOn,
       } = this.props;
 
-      if (!intents.length) return;
+      if (!Array.isArray(intents) || !intents.length) return;
 
       intents.forEach((intent) => {
         switch (intent.type) {


### PR DESCRIPTION
This line throw error `intents is undefined` when render FieldSet of checkboxes in custom Control component.